### PR TITLE
Support for String and int item values.

### DIFF
--- a/ESP32ZabbixSender.cpp
+++ b/ESP32ZabbixSender.cpp
@@ -43,7 +43,19 @@ void ESP32ZabbixSender::ClearItem(void) { // Clear item list
 	zabbixItemSize = 0;
 }
 
-void ESP32ZabbixSender::AddItem(String key, float value) {
+void ESP32ZabbixSender::AddItemFloat(String key, float value) {
+	zabbixItemList[zabbixItemSize].key = key;
+	zabbixItemList[zabbixItemSize].val = String(value);
+	zabbixItemSize++;
+}
+
+void ESP32ZabbixSender::AddItemInt(String key, int value) {
+	zabbixItemList[zabbixItemSize].key = key;
+	zabbixItemList[zabbixItemSize].val = String(value);
+	zabbixItemSize++;
+}
+
+void ESP32ZabbixSender::AddItemString(String key, String value) {
 	zabbixItemList[zabbixItemSize].key = key;
 	zabbixItemList[zabbixItemSize].val = value;
 	zabbixItemSize++;

--- a/ESP32ZabbixSender.h
+++ b/ESP32ZabbixSender.h
@@ -1,11 +1,7 @@
 #ifndef _ESP32ZabbixSender_H_
 #define _ESP32ZabbixSender_H_
 
-#if ARDUINO >= 100
 #include "Arduino.h"
-#else
-#include "WProgram.h"
-#endif
 
 #include <WiFi.h>
 #define ZABBIXMAXLEN 300 // max 256byte packet
@@ -18,13 +14,15 @@ public:
 	void Init(IPAddress ZabbixServerAddr, uint16_t ZabbixServerPort, String ZabbixItemHostName);
 	int Send(void);
 	void ClearItem(void);
-	void AddItem(String key, float value);
+	void AddItemFloat(String key, float value);
+	void AddItemInt(String key, float value);
+	void AddItemString(String key, String value);
 
 private:
 	int createZabbixPacket(void);
 	struct zabbixCell {
 		String key;
-		float val;
+		String val;
 	};
 	WiFiClient zClient;
 	IPAddress zAddr;

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ See `sample_ESP32ZabbixSender/sample_ESP32ZabbixSender.ino`
     ESP32ZabbixSender zSender;
     zSender.Init(IPAddress(192, 168, 35, 14), 10051, "IOTBOARD_00"); // Init zabbix server address, port, and hostname of item
     zSender.ClearItem(); // clear item list
-    zSender.AddItem("air.temp", 29.62); // add item such as air temperture
-    zSender.AddItem("air.hum", 70.60); // add item such as air humidity
+    zSender.AddItemFloat("air.temp", 29.62);		// add float item such as air temperture.
+    zSender.AddItemFloat("air.hum", 70.60);			// add float item such as air humidity.
+	zSender.AddItemInt("timeout", 1);				// add integer item such as a counter or settings value.
+	zSender.AddItemString("status", "Idle");		// add String item such as a status string or any other String value.
     if (zSender.Send() == EXIT_FAILURE){ // send packet
         // error handling
     }

--- a/sample_ESP32ZabbixSender/sample_ESP32ZabbixSender.ino
+++ b/sample_ESP32ZabbixSender/sample_ESP32ZabbixSender.ino
@@ -26,12 +26,14 @@ void setup() {
 
 void loop() {
 	static int counter1 = 1;
-	static int counter2 = 1;
-	checkConnection();							  // Check wifi connection
-	zSender.ClearItem();						  // Clear ZabbixSender's item list
-	zSender.AddItem("counter1", (float)counter1); // Exmaple value of zabbix trapper item
-	zSender.AddItem("counter2", (float)counter2); // Exmaple value of zabbix trapper item
-	if (zSender.Send() == EXIT_SUCCESS) {		  // Send zabbix items
+	static float counter2 = 1;
+	static String stringValue = "Hello World!";
+	checkConnection();									// Check wifi connection
+	zSender.ClearItem();								// Clear ZabbixSender's item list
+	zSender.AddItemInt("counter1", counter1);			// Example value of an zabbix integer trapper item
+	zSender.AddItemFloat("counter2", counter2);			// Example value of an zabbix float trapper item
+	zSender.AddItemString("stringvalue", stringValue);	// Example value of an string zabbix trapper item
+	if (zSender.Send() == EXIT_SUCCESS) {				// Send zabbix items
 		Serial.println("ZABBIX SEND: OK");
 	} else {
 		Serial.println("ZABBIX SEND: NG");


### PR DESCRIPTION
Added support for String and integer values:
```
zSender.AddItemInt("counter1", counter1);			// Example value of an zabbix integer trapper item
zSender.AddItemFloat("counter2", counter2);			// Example value of an zabbix float trapper item
zSender.AddItemString("stringvalue", stringValue);	// Example value of an string zabbix trapper item
```
